### PR TITLE
Add Appveyor integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Augurk
 ======
-[![Build status](https://ci.appveyor.com/api/projects/status/99dioh0vd3xjjmi4/branch/master?svg=true)](https://ci.appveyor.com/project/augurk/augurk-commandline/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/elxscd2cr60jkx35/branch/master?svg=true)](https://ci.appveyor.com/project/augurk/augurk-commandline/branch/master)
 
 Augurk is a work-in-progress living documentation system created especially to be used 
 in conjunction with [SpecFlow](http://www.specflow.org) and 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Augurk
 ======
+[![Build status](https://ci.appveyor.com/api/projects/status/99dioh0vd3xjjmi4/branch/master?svg=true)](https://ci.appveyor.com/project/augurk/augurk-commandline/branch/master)
 
 Augurk is a work-in-progress living documentation system created especially to be used 
 in conjunction with [SpecFlow](http://www.specflow.org) and 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: 2.3.1.{build}
 before_build:
 - cmd: nuget restore src/Augurk.CommandLine.sln
 build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,5 @@
+version: 1.0.{build}
+before_build:
+- cmd: nuget restore src/Augurk.CommandLine.sln
+build:
+  verbosity: minimal


### PR DESCRIPTION
Hi! Appveyor allows you to build your open source project for free so I added a config to get you guys up and running. 

You still have go allow Appveyor to integrate with Augurk/Augurk.CommandLine but after that your build should succeed and you could add a build-badge to show that your build is passing.