### PR TITLE
Ignore unknown arguments

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,4 @@
+next-version: 2.3.2
+branches: {}
+ignore:
+  sha: []

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ assembly_info:
 before_build:
 - cmd: nuget restore src\Augurk.CommandLine.sln
 - ps: gitversion /l console /output buildserver /updateAssemblyInfo
+configuration: Release
 build:
   verbosity: minimal
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,11 @@ install:
 assembly_info:
   patch: false
 before_build:
-- cmd: nuget restore src/Augurk.CommandLine.sln
+- cmd: nuget restore src\Augurk.CommandLine.sln
 - ps: gitversion /l console /output buildserver /updateAssemblyInfo
 build:
   verbosity: minimal
 after_build:
-  - cmd: ECHO nuget pack src/Augurk.CommandLine/Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
-  - cmd: nuget pack src/Augurk.CommandLine/Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
+  - cmd: ECHO nuget pack src\Augurk.CommandLine\Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
+  - cmd: nuget pack src\Augurk.CommandLine\Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
   - cmd: appveyor PushArtifact "Augurk.CommandLine.%GitVersion_NuGetVersion%.nupkg"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,13 @@
-version: 2.3.2.{build}
+install:
+- choco install gitversion.portable -pre -y
 assembly_info:
-  patch: true
-  file: '**\AssemblyInfo.*'
-  assembly_version: '{version}'
-  assembly_file_version: '{version}'
-  assembly_informational_version: '{version}'
-pull_requests:
-  do_not_increment_build_number: true
+  patch: false
 before_build:
 - cmd: nuget restore src/Augurk.CommandLine.sln
+- ps: gitversion /l console /output buildserver /updateAssemblyInfo
 build:
-  publish_nuget: true
-  publish_nuget_symbols: false
-  include_nuget_references: true
   verbosity: minimal
+after_build:
+  - cmd: ECHO nuget pack <Project>\<NuSpec>.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
+  - cmd: nuget pack <Project>\<NuSpec>.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
+  - cmd: appveyor PushArtifact "<NuSpec>.%GitVersion_NuGetVersion%.nupkg"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,6 @@ before_build:
 build:
   verbosity: minimal
 after_build:
-  - cmd: ECHO nuget pack <Project>\<NuSpec>.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
-  - cmd: nuget pack <Project>\<NuSpec>.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
-  - cmd: appveyor PushArtifact "<NuSpec>.%GitVersion_NuGetVersion%.nupkg"
+  - cmd: ECHO nuget pack src/Augurk.CommandLine/Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
+  - cmd: nuget pack src/Augurk.CommandLine/Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
+  - cmd: appveyor PushArtifact "Augurk.CommandLine.%GitVersion_NuGetVersion%.nupkg"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,6 @@ build:
   verbosity: minimal
 after_build:
   - cmd: cd src\Augurk.CommandLine
-  - cmd: ECHO nuget pack Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
-  - cmd: nuget pack Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
+  - cmd: ECHO nuget pack Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "Configuration=%CONFIGURATION%"
+  - cmd: nuget pack Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "Configuration=%CONFIGURATION%"
   - cmd: appveyor PushArtifact "Augurk.CommandLine.%GitVersion_NuGetVersion%.nupkg"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,16 @@
-version: 2.3.1.{build}
+version: 2.3.2.{build}
+assembly_info:
+  patch: true
+  file: '**\AssemblyInfo.*'
+  assembly_version: '{version}'
+  assembly_file_version: '{version}'
+  assembly_informational_version: '{version}'
+pull_requests:
+  do_not_increment_build_number: true
 before_build:
 - cmd: nuget restore src/Augurk.CommandLine.sln
 build:
+  publish_nuget: true
+  publish_nuget_symbols: false
+  include_nuget_references: true
   verbosity: minimal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ before_build:
 build:
   verbosity: minimal
 after_build:
-  - cmd: ECHO nuget pack src\Augurk.CommandLine\Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
-  - cmd: nuget pack src\Augurk.CommandLine\Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
+  - cmd: cd src\Augurk.CommandLine
+  - cmd: ECHO nuget pack Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
+  - cmd: nuget pack Augurk.CommandLine.nuspec -version "%GitVersion_NuGetVersion%" -prop "target=%CONFIGURATION%"
   - cmd: appveyor PushArtifact "Augurk.CommandLine.%GitVersion_NuGetVersion%.nupkg"

--- a/src/Augurk.CommandLine.sln
+++ b/src/Augurk.CommandLine.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Augurk.CommandLine", "Augurk.CommandLine\Augurk.CommandLine.csproj", "{3D0E1E13-76C3-4CB7-B864-0F3D93672144}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F906F5D3-BF38-45D1-9510-C422597C5D08}"
+	ProjectSection(SolutionItems) = preProject
+		..\appveyor.yml = ..\appveyor.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Augurk.CommandLine.sln
+++ b/src/Augurk.CommandLine.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F906F5D3-BF38-45D1-9510-C422597C5D08}"
 	ProjectSection(SolutionItems) = preProject
 		..\appveyor.yml = ..\appveyor.yml
+		..\GitVersion.yml = ..\GitVersion.yml
 	EndProjectSection
 EndProject
 Global

--- a/src/Augurk.CommandLine/Program.cs
+++ b/src/Augurk.CommandLine/Program.cs
@@ -23,7 +23,7 @@ namespace Augurk.CommandLine
             // Parse the command line arguments
             int exitCode = 0;
             var options = new GlobalOptions();
-            using (var parser = new Parser(settings => { settings.MutuallyExclusive = true; settings.HelpWriter = Console.Error; }))
+            using (var parser = new Parser(settings => { settings.IgnoreUnknownArguments = true; settings.MutuallyExclusive = true; settings.HelpWriter = Console.Error; }))
             {
                 if (!parser.ParseArguments(args, options, ExecuteVerb))
                 {


### PR DESCRIPTION
Changed the way we handle command line arguments so that unknown arguments are just ignored, instead of displaying the usage to the user. This allows us to future proof the command line tool and decoupling the TFS build task from the command line tool.

Might want to squash merge this since I've also spent some time to properly setup our automated build. We're using GitVersion now to automatically generate a version number based on branches, tags, etc. I've also setup deployment from AppVeyor to NuGet.