### PR TITLE
Added a prune command

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 3.1.1
+next-version: 3.2.0
 branches: {}
 ignore:
   sha: []

--- a/src/Augurk.CommandLine/Augurk.CommandLine.csproj
+++ b/src/Augurk.CommandLine/Augurk.CommandLine.csproj
@@ -79,11 +79,14 @@
     <Compile Include="Commands\DeleteCommand.cs" />
     <Compile Include="Commands\ICommand.cs" />
     <Compile Include="Commands\ICommandMetadata.cs" />
+    <Compile Include="Commands\PruneCommand.cs" />
     <Compile Include="Commands\PublishCommand.cs" />
     <Compile Include="Entities\Background.cs" />
     <Compile Include="Entities\BlockKeyword.cs" />
     <Compile Include="Entities\ExampleSet.cs" />
     <Compile Include="Entities\Feature.cs" />
+    <Compile Include="Entities\FeatureDescription.cs" />
+    <Compile Include="Entities\FeatureGroup.cs" />
     <Compile Include="Entities\Scenario.cs" />
     <Compile Include="Entities\SourceLocation.cs" />
     <Compile Include="Entities\Step.cs" />
@@ -94,6 +97,7 @@
     <Compile Include="Extensions\GherkinEntityExtensions.cs" />
     <Compile Include="Options\DeleteOptions.cs" />
     <Compile Include="Options\GlobalOptions.cs" />
+    <Compile Include="Options\PruneOptions.cs" />
     <Compile Include="Options\PublishOptions.cs" />
     <Compile Include="Options\SharedOptions.cs" />
     <Compile Include="Plumbing\AugurkDialectProvider.cs" />

--- a/src/Augurk.CommandLine/Commands/PruneCommand.cs
+++ b/src/Augurk.CommandLine/Commands/PruneCommand.cs
@@ -76,7 +76,12 @@ namespace Augurk.CommandLine.Commands
                                 versionsToDelete = versions.Where(version => Regex.Match(version, _options.VersionRegex).Success).ToList();
                             }
 
-                            Console.WriteLine($"\tFound {versions.Count} versions for feature {feature.Title} of which {versionsToDelete.Count} will be deleted");
+                            Console.WriteLine($"\tFound {versions.Count} version(s) for feature {feature.Title} of which {versionsToDelete.Count} will be deleted");
+
+                            foreach (var versionToDelete in versionsToDelete)
+                            {
+                                DeleteVersionOfFeature(client, group.Name, feature, versionToDelete);
+                            }
                         }
                     }
                 }
@@ -113,11 +118,17 @@ namespace Augurk.CommandLine.Commands
         private IEnumerable<string> GetVersionsForFeature(HttpClient client, string groupName, FeatureDescription feature)
         {
             var versionsUri = $"{_options.AugurkUrl}/api/v2/products/{_options.ProductName}/groups/{groupName}/features/{feature.Title}/versions";
-            Console.WriteLine(versionsUri);
             var response = client.GetAsync(versionsUri).Result;
             response.EnsureSuccessStatusCode();
 
             return JsonConvert.DeserializeObject<IEnumerable<string>>(response.Content.ReadAsStringAsync().Result);
+        }
+
+        private void DeleteVersionOfFeature(HttpClient client, string groupName, FeatureDescription feature, string version)
+        {
+            var versionUri = $"{_options.AugurkUrl}/api/v2/products/{_options.ProductName}/groups/{groupName}/features/{feature.Title}/versions/{version}/";
+            var response = client.DeleteAsync(versionUri).Result;
+            response.EnsureSuccessStatusCode();
         }
     }
 }

--- a/src/Augurk.CommandLine/Commands/PruneCommand.cs
+++ b/src/Augurk.CommandLine/Commands/PruneCommand.cs
@@ -52,13 +52,13 @@ namespace Augurk.CommandLine.Commands
         /// </summary>
         public void Execute()
         {
-            Console.WriteLine($"Pruning features in Augurk at {_options.AugurkUrl}");
+            Console.WriteLine($"Pruning features for product {_options.ProductName} in Augurk at {_options.AugurkUrl}");
             using (var client = AugurkHttpClientFactory.CreateHttpClient(_options))
             {
                 try
                 {
                     // Get features of the provided product (and group name if provided)
-                    var groups = string.IsNullOrWhiteSpace(_options.GroupName) ? this.GetFeaturesForProduct(client) : this.GetFeaturesForGroup(client);
+                    var groups = string.IsNullOrWhiteSpace(_options.GroupName) ? this.GetGroupsForProduct(client) : this.GetFeaturesForGroup(client);
                     foreach (var group in groups)
                     {
                         Console.WriteLine($"Processing features in group {group.Name}");
@@ -84,6 +84,8 @@ namespace Augurk.CommandLine.Commands
                             }
                         }
                     }
+
+                    Console.WriteLine("Finished pruning features.");
                 }
                 catch (Exception ex)
                 {
@@ -93,7 +95,7 @@ namespace Augurk.CommandLine.Commands
             }
         }
 
-        private IEnumerable<FeatureGroup> GetFeaturesForProduct(HttpClient client)
+        private IEnumerable<FeatureGroup> GetGroupsForProduct(HttpClient client)
         {
             var groupsUri = $"{_options.AugurkUrl}/api/v2/products/{_options.ProductName}/groups";
             var response = client.GetAsync(groupsUri).Result;
@@ -128,6 +130,7 @@ namespace Augurk.CommandLine.Commands
         {
             var versionUri = $"{_options.AugurkUrl}/api/v2/products/{_options.ProductName}/groups/{groupName}/features/{feature.Title}/versions/{version}/";
             var response = client.DeleteAsync(versionUri).Result;
+            Console.WriteLine($"\t\tDeleted version {version} of feature {feature.Title}");
             response.EnsureSuccessStatusCode();
         }
     }

--- a/src/Augurk.CommandLine/Commands/PruneCommand.cs
+++ b/src/Augurk.CommandLine/Commands/PruneCommand.cs
@@ -1,0 +1,123 @@
+﻿/*
+ Copyright 2017, Augurk
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+using Augurk.CommandLine.Entities;
+using Augurk.CommandLine.Options;
+using Augurk.CommandLine.Plumbing;
+using Newtonsoft.Json;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Net.Http;
+using System.Text.RegularExpressions;
+
+namespace Augurk.CommandLine.Commands
+{
+    /// <summary>
+    /// Implements the prune command.
+    /// </summary>
+    [Export(typeof(ICommand))]
+    [ExportMetadata("Verb", PruneOptions.VERB_NAME)]
+    internal class PruneCommand : ICommand
+    {
+        private readonly PruneOptions _options;
+
+        /// <summary>
+        /// Default constructor for this class.
+        /// </summary>
+        /// <param name="options">A <see cref="PruneOptions"/> instance containing the relevant options for the command.</param>
+        [ImportingConstructor]
+        public PruneCommand(PruneOptions options)
+        {
+            _options = options;
+        }
+
+
+        /// <summary>
+        /// Called when the command is to be executed.
+        /// </summary>
+        public void Execute()
+        {
+            Console.WriteLine($"Pruning features in Augurk at {_options.AugurkUrl}");
+            using (var client = AugurkHttpClientFactory.CreateHttpClient(_options))
+            {
+                try
+                {
+                    // Get features of the provided product (and group name if provided)
+                    var groups = string.IsNullOrWhiteSpace(_options.GroupName) ? this.GetFeaturesForProduct(client) : this.GetFeaturesForGroup(client);
+                    foreach (var group in groups)
+                    {
+                        Console.WriteLine($"Processing features in group {group.Name}");
+                        foreach (var feature in group.Features)
+                        {
+                            var versions = this.GetVersionsForFeature(client, group.Name, feature).ToList();
+
+                            List<string> versionsToDelete;
+                            if (_options.PrereleaseOnly)
+                            {
+                                versionsToDelete = versions.Where(version => version.Contains("-")).ToList();
+                            }
+                            else
+                            {
+                                versionsToDelete = versions.Where(version => Regex.Match(version, _options.VersionRegex).Success).ToList();
+                            }
+
+                            Console.WriteLine($"\tFound {versions.Count} versions for feature {feature.Title} of which {versionsToDelete.Count} will be deleted");
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"An error occured while pruning features in Augurk at {_options.AugurkUrl}");
+                    Console.Error.WriteLine(ex.ToString());
+                }
+            }
+        }
+
+        private IEnumerable<FeatureGroup> GetFeaturesForProduct(HttpClient client)
+        {
+            var groupsUri = $"{_options.AugurkUrl}/api/v2/products/{_options.ProductName}/groups";
+            var response = client.GetAsync(groupsUri).Result;
+            response.EnsureSuccessStatusCode();
+
+            return JsonConvert.DeserializeObject<IEnumerable<FeatureGroup>>(response.Content.ReadAsStringAsync().Result);
+        }
+
+        private IEnumerable<FeatureGroup> GetFeaturesForGroup(HttpClient client)
+        {
+            var groupUri = $"{_options.AugurkUrl}/api/v2/products/{_options.ProductName}/groups/{_options.GroupName}/features";
+            var response = client.GetAsync(groupUri).Result;
+            response.EnsureSuccessStatusCode();
+
+            return new FeatureGroup[] { new FeatureGroup
+            {
+                Name = _options.GroupName,
+                Features = JsonConvert.DeserializeObject<IEnumerable<FeatureDescription>>(response.Content.ReadAsStringAsync().Result)
+            } };
+        }
+
+        private IEnumerable<string> GetVersionsForFeature(HttpClient client, string groupName, FeatureDescription feature)
+        {
+            var versionsUri = $"{_options.AugurkUrl}/api/v2/products/{_options.ProductName}/groups/{groupName}/features/{feature.Title}/versions";
+            Console.WriteLine(versionsUri);
+            var response = client.GetAsync(versionsUri).Result;
+            response.EnsureSuccessStatusCode();
+
+            return JsonConvert.DeserializeObject<IEnumerable<string>>(response.Content.ReadAsStringAsync().Result);
+        }
+    }
+}

--- a/src/Augurk.CommandLine/Entities/FeatureDescription.cs
+++ b/src/Augurk.CommandLine/Entities/FeatureDescription.cs
@@ -1,0 +1,41 @@
+﻿/*
+ Copyright 2017, Augurk
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace Augurk.CommandLine.Entities
+{
+    /// <summary>
+    /// Represents a feature in Augurk.
+    /// </summary>
+    public class FeatureDescription
+    {
+        /// <summary>
+        /// Gets or sets the title of this feature.
+        /// </summary>
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the latest version available of this feature.
+        /// </summary>
+        public string LatestVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets an enumerable collection of the descriptions of the child features of this feature.
+        /// </summary>
+        public IEnumerable<FeatureDescription> ChildFeatures { get; set; }
+    }
+}

--- a/src/Augurk.CommandLine/Entities/FeatureGroup.cs
+++ b/src/Augurk.CommandLine/Entities/FeatureGroup.cs
@@ -1,0 +1,36 @@
+﻿/*
+ Copyright 2017, Augurk
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace Augurk.CommandLine.Entities
+{
+    /// <summary>
+    /// Represents a group in Augurk.
+    /// </summary>
+    public class FeatureGroup
+    {
+        /// <summary>
+        /// Gets or sets the name of this group.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets an enumerable collection containing the features in this group.
+        /// </summary>
+        public IEnumerable<FeatureDescription> Features { get; set; }
+    }
+}

--- a/src/Augurk.CommandLine/Options/GlobalOptions.cs
+++ b/src/Augurk.CommandLine/Options/GlobalOptions.cs
@@ -37,6 +37,12 @@ namespace Augurk.CommandLine.Options
         public DeleteOptions DeleteVerb { get; set; }
 
         /// <summary>
+        /// Options when pruning features.
+        /// </summary>
+        [VerbOption(PruneOptions.VERB_NAME, HelpText = "Prunes specific versions from products in Augurk.")]
+        public PruneOptions PruneVerb { get; set; }
+
+        /// <summary>
         /// Gets the usage of the command line tool for the specified verb.
         /// </summary>
         /// <param name="verb">Name of the verb for which the usage should be retrieved.</param>

--- a/src/Augurk.CommandLine/Options/PruneOptions.cs
+++ b/src/Augurk.CommandLine/Options/PruneOptions.cs
@@ -1,0 +1,55 @@
+﻿/*
+ Copyright 2017, Augurk
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+using CommandLine;
+
+namespace Augurk.CommandLine.Options
+{
+    /// <summary>
+    /// Represents the available command line options for the prune command.
+    /// </summary>
+    internal class PruneOptions : SharedOptions
+    {
+        /// <summary>
+        /// Name of the verb for this set of options
+        /// </summary>
+        public const string VERB_NAME = "prune";
+
+        /// <summary>
+        /// Gets or sets the name of the product for which to prune the features.
+        /// </summary>
+        [Option("productName", HelpText = "Name of the product for which to prune the features.", Required = true)]
+        public string ProductName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the optional name of the group for which to prune the features.
+        /// </summary>
+        [Option("groupName", HelpText = "Name of the group containing the features to delete.", Required = false)]
+        public string GroupName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean value indicating whether pre-release versions should be pruned.
+        /// </summary>
+        [Option("prerelease", HelpText = "Indicates that pre-release feature versions for which a matching release version exists should be pruned.", MutuallyExclusiveSet = "version", Required = false)]
+        public bool PrereleaseOnly { get; set; }
+
+        /// <summary>
+        /// 'Gets or sets a regular expression that should be run on the feature version in order to determine if it should be pruned.
+        /// </summary>
+        [Option("versionRegex", HelpText = "A regular expression that determines the versions that should be pruned.", MutuallyExclusiveSet = "version", Required = false)]
+        public string VersionRegex { get; set; }
+    }
+}

--- a/src/Augurk.CommandLine/Options/SharedOptions.cs
+++ b/src/Augurk.CommandLine/Options/SharedOptions.cs
@@ -32,13 +32,13 @@ namespace Augurk.CommandLine.Options
         /// <summary>
         /// Flag to indicate that the tool must run under integrated security to access the Augurk API's.
         /// </summary>
-        [Option("useIntegratedSecurity", HelpText = "Use integrated security to access the Augurk API's. Do not specify username and password when using integrated security", MutuallyExclusiveSet = "username,password,useBasicAuthentication", Required = false)]
+        [Option("useIntegratedSecurity", HelpText = "Use integrated security to access the Augurk API's. Do not specify username and password when using integrated security", MutuallyExclusiveSet = "security", Required = false)]
         public bool UseIntegratedSecurity { get; set; }
 
         /// <summary>
         /// Flag to indicate that the tool must use basic HTTP authentication to access the Augurk API's.
         /// </summary>
-        [Option("useBasicAuthentication", HelpText = "Use basic HTTP authentication to access the Augurk API's. You must also specify a username and a password.", MutuallyExclusiveSet = "useIntegratedSecurity", Required = false)]
+        [Option("useBasicAuthentication", HelpText = "Use basic HTTP authentication to access the Augurk API's. You must also specify a username and a password.", MutuallyExclusiveSet = "security", Required = false)]
         public bool UseBasicAuthentication { get; set; }
 
         /// <summary>


### PR DESCRIPTION
This PR adds a prune command to Augurk.CommandLine. This command can be used to cleanup an Augurk installation that has grown out of control by removing versions that match a particular regular expression, or any prerelease versions if you're using Semantic Versioning.

Fixes augurk/Augurk#51