### PR TITLE
Skip processing when description is null

### DIFF
--- a/src/Augurk.CommandLine/Commands/PublishCommand.cs
+++ b/src/Augurk.CommandLine/Commands/PublishCommand.cs
@@ -279,7 +279,10 @@ namespace Augurk.CommandLine.Commands
 
         private string ProcessDescription(string originalDescription)
         {
-            if (originalDescription == null) { return originalDescription; }
+            if (String.IsNullOrEmpty(originalDescription)) 
+            { 
+                return originalDescription; 
+            }
 
             string result = originalDescription;
             if (_options.CompatibilityLevel <= 2)

--- a/src/Augurk.CommandLine/Commands/PublishCommand.cs
+++ b/src/Augurk.CommandLine/Commands/PublishCommand.cs
@@ -279,6 +279,8 @@ namespace Augurk.CommandLine.Commands
 
         private string ProcessDescription(string originalDescription)
         {
+            if (originalDescription == null) { return originalDescription; }
+
             string result = originalDescription;
             if (_options.CompatibilityLevel <= 2)
             {


### PR DESCRIPTION
Fixed an issue where publishing would fail when the --embed is used and not all scenario's have a description.